### PR TITLE
Removed offending Memo

### DIFF
--- a/etc/services.db
+++ b/etc/services.db
@@ -130,7 +130,6 @@ CF +AFORVbefiorstv
 MU AAAAAAAAH admin $1$bmrxgk$Siw9LW0dne1B6xGZx13Q0/ em@ai.l 1343918197 1420582473 +sC default 
 MDU admin private:host:actual ~errietta@127.0.0.1
 MDU admin private:host:vhost ~errietta@127.0.0.1
-ME admin admin 1420494232 0 fuck
 ME admin gms 1420494261 1 Your request                        for the group registration of mysecondgroup has been approved.
 ME admin gms 1420494713 1 Your request for a GroupContactChange change for mysecondgroup has been approved.
 ME admin gms 1420494742 1 Your request for a the CloakNamespace namespace fuuu for mysecondgroup has been approved.


### PR DESCRIPTION
There was an offending memo that was by default unread for the admin
account.
Maybe there should instead be start instructions?