### PR TITLE
Fix an unclosed HTML tag

### DIFF
--- a/root/src/wrapper.tt
+++ b/root/src/wrapper.tt
@@ -81,6 +81,7 @@
                     [% content %]
                 </div>
             </div>
+        </div>
       </body>
     </html>
 [% ELSE -%]


### PR DESCRIPTION
An unclosed `<div>` tag in the wrapper template causes nearly all pages output invalid HTML.