### PR TITLE
Disallow cloaks ending with a slash.

### DIFF
--- a/lib/GMS/Schema/Result/CloakChange.pm
+++ b/lib/GMS/Schema/Result/CloakChange.pm
@@ -252,7 +252,10 @@ sub new {
         } elsif (length $args->{cloak} > 63) {
             push @errors, "The cloak is too long.";
             $valid = 0;
-        } elsif ( (split '', $parts[-1])[0] =~ /[0-9]/ ) {
+        } elsif ($role =~ qr|/$|) {
+            push @errors, "The cloak cannot end with a slash.";
+            $valid = 0;
+        } elsif ($parts[-1] =~ /^[0-9]/) {
             push @errors, "The cloak provided looks like a CIDR mask.";
             $valid = 0;
         }

--- a/t/27schema_cloak_changes.t
+++ b/t/27schema_cloak_changes.t
@@ -103,6 +103,14 @@ throws_ok {
 throws_ok {
     $schema->resultset('CloakChange')->create({
             'target'     => '3EAB67EC',
+            'cloak'      => 'cloak/foo/bar/',
+            'changed_by' => '3EAB67EC',
+        })
+} qr/The cloak cannot end with a slash/;
+
+throws_ok {
+    $schema->resultset('CloakChange')->create({
+            'target'     => '3EAB67EC',
             'cloak'      => 'cloak/42',
             'changed_by' => '3EAB67EC',
         })

--- a/t/541web_group_request_cloak.t
+++ b/t/541web_group_request_cloak.t
@@ -120,7 +120,7 @@ $ua->submit_form(
     }
 );
 
-$ua->content_contains("The cloak contains invalid characters", "Can't have invalid cloak");
+$ua->content_contains("The role/user contains invalid characters", "Can't have invalid cloak");
 
 $ua->get_ok("http://localhost/group/2/cloak", "Cloak page works");
 
@@ -173,6 +173,19 @@ $ua->submit_form(
 );
 
 $ua->content_contains("The cloak provided looks like a CIDR mask", "Can't have invalid cloak");
+
+$ua->get_ok("http://localhost/group/2/cloak", "cloak page works");
+
+$ua->submit_form(
+    fields => {
+        'num_cloaks' => 1,
+        'accountname_0' => 'account0',
+        'cloak_namespace_0' => 'group0',
+        'cloak_0' => 'foo/bar/'
+    }
+);
+
+$ua->content_contains("The cloak cannot end with a slash", "Can't have invalid cloak");
 
 $ua->get_ok("http://localhost/group/2/cloak", "cloak page works");
 


### PR DESCRIPTION
 Fixes #75. The code should now be congruent with all vhost checks in the ircd-seven protocol module