### PR TITLE
Per-request limit for cloak assignments.

### DIFF
--- a/lib/GMS/Web/Controller/Group.pm
+++ b/lib/GMS/Web/Controller/Group.pm
@@ -744,6 +744,7 @@ sub do_cloak :Chained('active_group') :PathPart('cloak/submit') :Args(0) {
     my $num = $p->{num_cloaks};
 
     my @errors;
+    my $empty_count = 0;
     my $error_count = 0;
     my $success_count = 0;
 
@@ -763,7 +764,13 @@ sub do_cloak :Chained('active_group') :PathPart('cloak/submit') :Args(0) {
         my $account;
 
         if ( !$accountname || !$namespace || !$cloak ) {
+            $empty_count++;
             next;
+        }
+
+        if ( $i - $empty_count >= 8 ) {
+            # requests are limited by the UI; violation is not a reported error.
+            last;
         }
 
         try {

--- a/root/static/js/group_cloak.js
+++ b/root/static/js/group_cloak.js
@@ -1,6 +1,7 @@
 //function addEventHandler (elem, eventType, handler) {
 var count = 1;
 var numElems = 0;
+var maxElems = 8;
 
 function removeBox (elem) {
     if ( numElems == 0) {
@@ -29,6 +30,11 @@ function removeBox (elem) {
     }
 
     --numElems;
+
+    if ( numElems+1 <= maxElems ) {
+        var add_button = document.getElementById(__ID_BTN_ADD);
+        add_button.style.visibility = 'visible';
+    }
 }
 
 addEventHandler ( window, 'load', function() {
@@ -38,6 +44,10 @@ addEventHandler ( window, 'load', function() {
 });
 
 function addAnother() {
+    if ( numElems+1 >= maxElems ) {
+        return;
+    }
+
     var container = document.getElementById(__ID_CLOAK_CONTAINER);
     var cloak = document.getElementById(__ID_CLOAK);
 
@@ -67,10 +77,24 @@ function addAnother() {
 
     document.getElementById(__ID_NUM_CLOAKS).setAttribute('value', ++count);
     ++numElems;
+
+    if ( numElems+1 > maxElems ) {
+        var add_button = document.getElementById(__ID_BTN_ADD);
+        add_button.style.visibility = 'hidden';
+    }
+
+    setTimeout ( function() {
+        addButtonClick ()
+    }, 1 );
 }
 
 function addButtonClick() {
     var input = document.getElementById(__ID_BTN_ADD);
+
+    if ( numElems+1 >= maxElems ) {
+        input.style.visibility = 'hidden';
+    }
+
     addEventHandler ( input, 'click', function() {
         addAnother();
     } );


### PR DESCRIPTION
The limit is magically 8 until integrated with some configuration.

This is a partial fix for #118: ideally, a pool of request slots
should be occupied with any remaining appearing available in the UI.